### PR TITLE
Update version of Promotion gem in gemfile to 1.2.0

### DIFF
--- a/files/Gemfile.erb
+++ b/files/Gemfile.erb
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rake"
-gem "ProMotion", "~> 1.1.2"
+gem "ProMotion", "~> 1.2.0"
 # gem "bubble-wrap" # lots of goodies
 # gem "sugarcube" # monkeypatch all the things
 # gem "rmq" # front end toolkit


### PR DESCRIPTION
The Gemfile created by the promotion executable from this repository should default to 1.2.0
